### PR TITLE
add missed nms_cuda.c

### DIFF
--- a/lib/model/nms/src/nms_cuda.c
+++ b/lib/model/nms/src/nms_cuda.c
@@ -1,0 +1,19 @@
+#include <THC/THC.h>
+#include <stdio.h>
+#include "nms_cuda_kernel.h"
+
+// this symbol will be resolved automatically from PyTorch libs
+extern THCState *state;
+
+int nms_cuda(THCudaIntTensor *keep_out, THCudaTensor *boxes_host,
+		     THCudaIntTensor *num_out, float nms_overlap_thresh) {
+
+    nms_cuda_compute(THCudaIntTensor_data(state, keep_out),
+                     THCudaIntTensor_data(state, num_out),
+                     THCudaTensor_data(state, boxes_host),
+                     THCudaTensor_size(state, boxes_host, 0),
+                     THCudaTensor_size(state, boxes_host, 1),
+                     nms_overlap_thresh);
+
+	return 1;
+}


### PR DESCRIPTION
This aims to fix issue #17. The compling error is actually caused by missing the file nms_cuda.c. I borrow the one in [Detectron.pytorch](https://github.com/roytseng-tw/Detectron.pytorch/blob/master/lib/model/nms/src/nms_cuda.c).

close #17 